### PR TITLE
`bpe_encoder` fails when file is not modified because `download()` returns `None`

### DIFF
--- a/promptify/models/nlp/utils/utils.py
+++ b/promptify/models/nlp/utils/utils.py
@@ -24,7 +24,7 @@ def download(url, destination_file):
     response.raise_for_status()
 
     if response.status_code == requests.codes.not_modified:
-        return
+        return destination_file
 
     if response.status_code == requests.codes.ok:
         with open(destination_file, "wb") as f:


### PR DESCRIPTION
When file is not modified, `download()` returns `None` [here](https://github.com/promptslab/Promptify/blob/main/promptify/models/nlp/utils/utils.py#L26):
```
if response.status_code == requests.codes.not_modified:
     return
```


This poses a problem because then `encoder_filename = None` when `bpe_encoder()` [tries to read the downloaded file](https://github.com/promptslab/Promptify/blob/main/promptify/models/nlp/utils/bpe_encoder.py#L109):
```
encoder_filename = download(encoder_file["link"], encoder_file["filename"]
```


I believe `download()` should return the filepath even if file was already downloaded and doesn't need to be updated. Is my understanding correct?