### PR TITLE
use bumpversion to manage versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,5 @@
+[bumpversion]
+files = promptify/VERSION promptify/__init__.py
+current_version = 0.1.4
+commit = True
+tag = True


### PR DESCRIPTION
[bumpversion](https://github.com/peritus/bumpversion) is a friendly-used tool to manage versions.

Supposed the current version is 0.1.4, run the following shell will change the version:

1) `bumpversion patch`: 0.1.4 -> 0.1.5

2) `bumpversion minor`: 0.1.4 -> 0.2.0

3) `bumpversion major`: 0.1.4 -> 1.0.0