### PR TITLE
Add/update OpenAI model parameters

### DIFF
--- a/promptify/models/nlp/openai_model.py
+++ b/promptify/models/nlp/openai_model.py
@@ -1,9 +1,18 @@
-from typing import List, Union
+import re
+from typing import Iterable, List, Optional, Union
 
 import openai
 
 from .model import Model
 from .utils import get_encoder
+
+GPT_MODEL_TOKENS = {
+    r'gpt-3.5-turbo((?=-).*)?': 4096,
+    r'.*-davinci-003':          4000,
+    r'.*-curie-001':            2048,
+    r'.*-babbage-001':          2048,
+    r'.*-ada-001':              2048,
+}
 
 
 class OpenAI(Model):
@@ -15,13 +24,13 @@ class OpenAI(Model):
         self.model = model
         self._openai = openai
         self._openai.api_key = self._api_key
-        self.supported_models = [
+        self.supported_models = (
+            "gpt-3.5-turbo",
             "text-davinci-003",
             "text-curie-001",
             "text-babbage-001",
             "text-ada-001",
-            "gpt-3.5-turbo",
-        ]
+        )
         self.encoder = get_encoder()
         assert self.model in self.list_models(), "model not supported"
 
@@ -38,61 +47,65 @@ class OpenAI(Model):
     def run(
         self,
         prompts: List[str],
-        temperature: float = 0.7,
-        max_tokens: int = 4000,
-        top_p: float = 0.1,
-        frequency_penalty: float = 0,
+        suffix: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: float = 0,
+        top_p: float = 1,
+        stop: Union[str, Iterable[str], None] = None,
         presence_penalty: float = 0,
-        stop: Union[str, None] = None,
+        frequency_penalty: float = 0,
     ):
         """
         prompts: The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
-        temperature: What sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
-                    We generally recommend altering this or top_p but not both.
         max_tokens: The maximum number of tokens to generate in the completion.
                     The token count of your prompt plus max_tokens cannot exceed the model's context length. Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
+        temperature: What sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+                    We generally recommend altering this or top_p but not both.
         top_p: An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
                 We generally recommend altering this or temperature but not both.
-        frequency_penalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
-        presence_penalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
         stop: Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+        presence_penalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+        frequency_penalty: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
         """
 
         result = []
 
         for prompt in prompts:
-            len_prompt_tokens = len(self.encoder.encode(prompt))
-            max_tokens_prompt = max_tokens - len_prompt_tokens
+            # Automatically calculate max output tokens if not specified
+            if not max_tokens:
+                prompt_tokens = len(self.encoder.encode(prompt))
+                model_max_tokens = next((v for k, v in GPT_MODEL_TOKENS.items() if re.fullmatch(k, self.model.lower())))
+                max_tokens = model_max_tokens - prompt_tokens
 
-            if self.model == "gpt-3.5-turbo":
+            data = {}
+            if self.model.startswith("gpt-3.5-turbo"):
                 response = self._openai.ChatCompletion.create(
-                    model="gpt-3.5-turbo",
-                    temperature=temperature,
-                    max_tokens=max_tokens_prompt,
+                    model=self.model,
                     messages=[{"role": "user", "content": prompt}],
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    stop=stop,
+                    presence_penalty=presence_penalty,
+                    frequency_penalty=frequency_penalty,
                 )
-
-                data = {}
-                data.update(response["usage"])
-                
                 data["text"] = response["choices"][0]["message"]["content"]
                 data["role"] = response["choices"][0]["message"]["role"]
-                result.append(data)
 
             else:
                 response = self._openai.Completion.create(
                     model=self.model,
                     prompt=prompt,
+                    max_tokens=max_tokens,
+                    suffix=suffix,
                     temperature=temperature,
-                    max_tokens=max_tokens_prompt,
                     top_p=top_p,
-                    frequency_penalty=frequency_penalty,
-                    presence_penalty=presence_penalty,
                     stop=stop,
+                    presence_penalty=presence_penalty,
+                    frequency_penalty=frequency_penalty,
                 )
-                data = {}
-                data.update(response["usage"])
                 data["text"] = response["choices"][0]["text"]
-                result.append(data)
+            data.update(response["usage"])
+            result.append(data)
 
         return result


### PR DESCRIPTION
Three changes to OpenAI model parameters
- Add `suffix` parameter to GPT Completion models (not available for ChatGPT)
- Add all other parameters to ChatCompletion models (`stop`, `top_p`, `frequency_penalty`, `presence_penalty`)
- Automatically determine max output tokens based on GPT model if `max_tokens` not specified
  - Currently, the user specifies max total tokens, and then max output tokens is automatically determined by deducting the prompt tokens. This is unintuitive because
    1. The user shouldn't have to keep track of the max total tokens for a given model
    2. The `max_tokens` parameter in OpenAI models refers to the max _output_ tokens, not max total, so we're using the phrase ambiguously here
  - I suggest the following, depending on whether user specifies `max_tokens`:
    - If unspecified (`max_tokens=None`), automatically determine max total tokens based on model name and deduct prompt tokens
    - If specified, simply use `max_tokens` as the max output tokens (aligning with how the OpenAI model uses it).

I apologize I also shuffled some other stuff around for vanity, and now it's hard to undo. I can remove those superfluous changes if you prefer.