### PR TITLE
Chatgpt turbo example

### DIFF
--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = OpenAI(api_key=\"\")\n",
+    "model = OpenAI(api_key=\"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\")\n",
     "nlp_prompter = Prompter(model)"
    ]
   },
@@ -39,7 +39,7 @@
     {
      "data": {
       "text/plain": [
-       "10"
+       "9"
       ]
      },
      "execution_count": 4,
@@ -118,7 +118,21 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "string indices must be integers",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m output \u001b[39m=\u001b[39m nlp_prompter\u001b[39m.\u001b[39;49mfit(\u001b[39m'\u001b[39;49m\u001b[39mbinary_classification.jinja\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      2\u001b[0m                  label_0\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mpositive\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      3\u001b[0m                  label_1\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mnegative\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m                  examples\u001b[39m=\u001b[39;49mexamples,\n\u001b[1;32m      5\u001b[0m                  text_input\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mAmazing customer service.\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      6\u001b[0m                  model_name\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mtext-davinci-003\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
+      "File \u001b[0;32m~/miniconda3/envs/prompt-env/lib/python3.9/site-packages/promptify-0.1.4-py3.9.egg/promptify/prompts/nlp/prompter.py:65\u001b[0m, in \u001b[0;36mPrompter.fit\u001b[0;34m(self, template_name, **kwargs)\u001b[0m\n\u001b[1;32m     62\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m     63\u001b[0m     prompt \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgenerate_prompt(template_name, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mprompt_kwargs)\n\u001b[0;32m---> 65\u001b[0m output \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mmodel\u001b[39m.\u001b[39;49mrun(prompts\u001b[39m=\u001b[39;49m[prompt], \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mmodel_kwargs)\n\u001b[1;32m     66\u001b[0m \u001b[39mreturn\u001b[39;00m output[\u001b[39m0\u001b[39m]\n",
+      "File \u001b[0;32m~/miniconda3/envs/prompt-env/lib/python3.9/site-packages/promptify-0.1.4-py3.9.egg/promptify/models/nlp/openai_model.py:70\u001b[0m, in \u001b[0;36mOpenAI.run\u001b[0;34m(self, prompts, temperature, max_tokens, top_p, frequency_penalty, presence_penalty, stop)\u001b[0m\n\u001b[1;32m     68\u001b[0m text_to_encode \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     69\u001b[0m \u001b[39mfor\u001b[39;00m message \u001b[39min\u001b[39;00m prompt:\n\u001b[0;32m---> 70\u001b[0m     text_to_encode \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m message[\u001b[39m\"\u001b[39;49m\u001b[39mcontent\u001b[39;49m\u001b[39m\"\u001b[39;49m] \u001b[39m+\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     71\u001b[0m len_prompt_tokens \u001b[39m=\u001b[39m \u001b[39mlen\u001b[39m(\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mencoder\u001b[39m.\u001b[39mencode(text_to_encode))\n\u001b[1;32m     72\u001b[0m max_tokens_prompt \u001b[39m=\u001b[39m max_tokens \u001b[39m-\u001b[39m len_prompt_tokens\n",
+      "\u001b[0;31mTypeError\u001b[0m: string indices must be integers"
+     ]
+    }
+   ],
    "source": [
     "output = nlp_prompter.fit('binary_classification.jinja',\n",
     "                 label_0=\"positive\",\n",
@@ -130,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -180,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -206,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -238,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = OpenAI(api_key=\"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\")\n",
+    "model = OpenAI(api_key=\"\")\n",
     "nlp_prompter = Prompter(model)"
    ]
   },
@@ -118,21 +118,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "string indices must be integers",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m output \u001b[39m=\u001b[39m nlp_prompter\u001b[39m.\u001b[39;49mfit(\u001b[39m'\u001b[39;49m\u001b[39mbinary_classification.jinja\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      2\u001b[0m                  label_0\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mpositive\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      3\u001b[0m                  label_1\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mnegative\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m                  examples\u001b[39m=\u001b[39;49mexamples,\n\u001b[1;32m      5\u001b[0m                  text_input\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mAmazing customer service.\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      6\u001b[0m                  model_name\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mtext-davinci-003\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
-      "File \u001b[0;32m~/miniconda3/envs/prompt-env/lib/python3.9/site-packages/promptify-0.1.4-py3.9.egg/promptify/prompts/nlp/prompter.py:65\u001b[0m, in \u001b[0;36mPrompter.fit\u001b[0;34m(self, template_name, **kwargs)\u001b[0m\n\u001b[1;32m     62\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m     63\u001b[0m     prompt \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgenerate_prompt(template_name, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mprompt_kwargs)\n\u001b[0;32m---> 65\u001b[0m output \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mmodel\u001b[39m.\u001b[39;49mrun(prompts\u001b[39m=\u001b[39;49m[prompt], \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mmodel_kwargs)\n\u001b[1;32m     66\u001b[0m \u001b[39mreturn\u001b[39;00m output[\u001b[39m0\u001b[39m]\n",
-      "File \u001b[0;32m~/miniconda3/envs/prompt-env/lib/python3.9/site-packages/promptify-0.1.4-py3.9.egg/promptify/models/nlp/openai_model.py:70\u001b[0m, in \u001b[0;36mOpenAI.run\u001b[0;34m(self, prompts, temperature, max_tokens, top_p, frequency_penalty, presence_penalty, stop)\u001b[0m\n\u001b[1;32m     68\u001b[0m text_to_encode \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     69\u001b[0m \u001b[39mfor\u001b[39;00m message \u001b[39min\u001b[39;00m prompt:\n\u001b[0;32m---> 70\u001b[0m     text_to_encode \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m message[\u001b[39m\"\u001b[39;49m\u001b[39mcontent\u001b[39;49m\u001b[39m\"\u001b[39;49m] \u001b[39m+\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     71\u001b[0m len_prompt_tokens \u001b[39m=\u001b[39m \u001b[39mlen\u001b[39m(\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mencoder\u001b[39m.\u001b[39mencode(text_to_encode))\n\u001b[1;32m     72\u001b[0m max_tokens_prompt \u001b[39m=\u001b[39m max_tokens \u001b[39m-\u001b[39m len_prompt_tokens\n",
-      "\u001b[0;31mTypeError\u001b[0m: string indices must be integers"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "output = nlp_prompter.fit('binary_classification.jinja',\n",
     "                 label_0=\"positive\",\n",
@@ -144,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -164,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -194,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +188,7 @@
      "output_type": "stream",
      "text": [
       "You are a highly intelligent and accurate Multiclass Classification system. You take Passage as input and classify that as one of the following appropriate Categories:\n",
-      "{'surprise', 'neutral', 'hate', 'joy', 'worry', 'sadness'}\n",
+      "{'surprise', 'neutral', 'sadness', 'worry', 'hate', 'joy'}\n",
       "Your output format is only [{{'C': Appropriate Category from the list of provided Categories}}] form, no other form.\n",
       "\n",
       "Input: Amazing customer service.\n",
@@ -220,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +227,7 @@
        "[{'C': 'joy'}]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -252,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -294,7 +280,7 @@
        " '[{\"main class\": \"Health\", \"1\": \"Medicine\", \"2\": \"Oncology\", \"3\": \"Metastasis\", \"4\": \"Breast cancer\", \"5\": \"Lung cancer\", \"6\": \"Cerebrospinal fluid\", \"7\": \"Tumor microenvironment\", \"8\": \"Single-cell RNA sequencing\", \"9\": \"Idiopathic intracranial hypertension\", \"branch\": \"Health\", \"group\": \"Clinical medicine\"}]')"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -348,9 +334,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "fit() missing 1 required positional argument: 'model_name'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m output \u001b[39m=\u001b[39m nlp_prompter\u001b[39m.\u001b[39;49mfit(\u001b[39m'\u001b[39;49m\u001b[39mmultilabel_classification.jinja\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      2\u001b[0m                                       n_output_labels\u001b[39m=\u001b[39;49m\u001b[39mlen\u001b[39;49m(labels),\n\u001b[1;32m      3\u001b[0m                                       domain\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mhealthcare\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m                                       labels\u001b[39m=\u001b[39;49mlabels,\n\u001b[1;32m      5\u001b[0m                                       examples\u001b[39m=\u001b[39;49m[examples[\u001b[39m0\u001b[39;49m]],\n\u001b[1;32m      6\u001b[0m                                       text_input\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mThe patient is a 93-year-old female with a medical history of chronic right hip pain, osteoporosis, hypertension, depression, and chronic atrial fibrillation admitted for evaluation and management of severe nausea and vomiting and urinary tract infection\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[1;32m      7\u001b[0m                                      )\n",
+      "\u001b[0;31mTypeError\u001b[0m: fit() missing 1 required positional argument: 'model_name'"
+     ]
+    }
+   ],
    "source": [
     "output = nlp_prompter.fit('multilabel_classification.jinja',\n",
     "                                      n_output_labels=len(labels),\n",
@@ -358,24 +356,25 @@
     "                                      labels=labels,\n",
     "                                      examples=[examples[0]],\n",
     "                                      text_input=\"The patient is a 93-year-old female with a medical history of chronic right hip pain, osteoporosis, hypertension, depression, and chronic atrial fibrillation admitted for evaluation and management of severe nausea and vomiting and urinary tract infection\",\n",
-    "                                     )"
+    "                                      model_name=\"text-davinci-003\")\n",
+    "                                     "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'prompt_tokens': 430,\n",
-       " 'completion_tokens': 59,\n",
-       " 'total_tokens': 489,\n",
-       " 'text': \"\\n\\n[[{'main class': Main Classification Category ,'1': 2nd level Classification Category, '2': 3rd level Classification Category,...,'branch' : Appropriate branch of the Passage ,'group': Appropriate Group of the Passage}] form, no other form.\"}"
+       "{'prompt_tokens': 93,\n",
+       " 'completion_tokens': 10,\n",
+       " 'total_tokens': 103,\n",
+       " 'text': \" [{'C': 'joy'}]\"}"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/turbo_example.ipynb
+++ b/examples/turbo_example.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = nlp_prompter.fit(prompt=initial_message, model=\"gpt-3.5-turbo\", template_name=\"bypass\")"
+    "output = nlp_prompter.fit(prompt=initial_message, model_name=\"gpt-3.5-turbo\", template_name=\"bypass\")"
    ]
   },
   {
@@ -66,9 +66,9 @@
      "data": {
       "text/plain": [
        "{'prompt_tokens': 23,\n",
-       " 'completion_tokens': 32,\n",
-       " 'total_tokens': 55,\n",
-       " 'text': 'Hello! As an AI language model, I do not have emotions, but I am always ready to assist you. How can I help you today?',\n",
+       " 'completion_tokens': 41,\n",
+       " 'total_tokens': 64,\n",
+       " 'text': \"Hello! As an AI language model, I don't have feelings like humans do, but I'm always ready to assist you to the best of my abilities. How may I assist you today?\",\n",
        " 'role': 'assistant'}"
       ]
      },
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,16 +93,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "second_user_message = {\"role\": \"user\", \"content\": \"I am good, how are you?\"}"
+    "second_user_message = {\"role\": \"user\", \"content\": \"Okay but if you had to pretend as one?\"}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,29 +111,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = nlp_prompter.fit(prompt=new_message, model=\"gpt-3.5-turbo\", template_name=\"bypass\")\n"
+    "output = nlp_prompter.fit(prompt=new_message, model_name=\"gpt-3.5-turbo\", template_name=\"bypass\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'prompt_tokens': 71,\n",
-       " 'completion_tokens': 35,\n",
-       " 'total_tokens': 106,\n",
-       " 'text': \"As an AI language model, I don't have emotions, but I'm functioning well and ready to assist you. Is there anything else I can help you with?\",\n",
+       "{'prompt_tokens': 82,\n",
+       " 'completion_tokens': 34,\n",
+       " 'total_tokens': 116,\n",
+       " 'text': 'As an AI language model, I can simulate emotions and respond in a way that is appropriate for a given situation. So, how may I assist you today?',\n",
        " 'role': 'assistant'}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/turbo_example.ipynb
+++ b/examples/turbo_example.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from promptify.models.nlp.openai_model import OpenAI\n",
+    "from promptify.prompts.nlp.prompter import Prompter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = OpenAI(api_key=\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nlp_prompter = Prompter(model)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initial_message = [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},{\"role\": \"user\", \"content\": \"Hello how are you?\"}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = nlp_prompter.fit(prompt=initial_message, model=\"gpt-3.5-turbo\", template_name=\"bypass\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'prompt_tokens': 23,\n",
+       " 'completion_tokens': 32,\n",
+       " 'total_tokens': 55,\n",
+       " 'text': 'Hello! As an AI language model, I do not have emotions, but I am always ready to assist you. How can I help you today?',\n",
+       " 'role': 'assistant'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_answer = output[\"text\"]\n",
+    "first_appended_message = {\"role\": \"assistant\", \"content\": first_answer}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second_user_message = {\"role\": \"user\", \"content\": \"I am good, how are you?\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_message = [initial_message[0], initial_message[1], first_appended_message, second_user_message]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = nlp_prompter.fit(prompt=new_message, model=\"gpt-3.5-turbo\", template_name=\"bypass\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'prompt_tokens': 71,\n",
+       " 'completion_tokens': 35,\n",
+       " 'total_tokens': 106,\n",
+       " 'text': \"As an AI language model, I don't have emotions, but I'm functioning well and ready to assist you. Is there anything else I can help you with?\",\n",
+       " 'role': 'assistant'}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "prompt-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/promptify/models/nlp/openai_model.py
+++ b/promptify/models/nlp/openai_model.py
@@ -10,7 +10,7 @@ class OpenAI(Model):
     name = "OpenAI"
     description = "OpenAI API for text completion using various models"
 
-    def __init__(self, api_key: str, model: str = "text-davinci-003"):
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
         self._api_key = api_key
         self.model = model
         self._openai = openai
@@ -37,7 +37,8 @@ class OpenAI(Model):
 
     def run(
         self,
-        prompts: List[str],
+        # prompts: List[str],
+        prompts,
         temperature: float = 0.7,
         max_tokens: int = 4000,
         top_p: float = 0.1,
@@ -61,15 +62,20 @@ class OpenAI(Model):
         result = []
 
         for prompt in prompts:
-            len_prompt_tokens = len(self.encoder.encode(prompt))
-            max_tokens_prompt = max_tokens - len_prompt_tokens
+
 
             if self.model == "gpt-3.5-turbo":
+                text_to_encode = ""
+                for message in prompt:
+                    text_to_encode += message["content"] + " "
+                len_prompt_tokens = len(self.encoder.encode(text_to_encode))
+                max_tokens_prompt = max_tokens - len_prompt_tokens
                 response = self._openai.ChatCompletion.create(
                     model="gpt-3.5-turbo",
                     temperature=temperature,
                     max_tokens=max_tokens_prompt,
-                    messages=[{"role": "user", "content": prompt}],
+                    # messages=[{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": prompt}],
+                    messages=prompt,
                 )
 
                 data = {}
@@ -80,6 +86,8 @@ class OpenAI(Model):
                 result.append(data)
 
             else:
+                len_prompt_tokens = len(self.encoder.encode(prompt))
+                max_tokens_prompt = max_tokens - len_prompt_tokens
                 response = self._openai.Completion.create(
                     model=self.model,
                     prompt=prompt,

--- a/promptify/models/nlp/openai_model.py
+++ b/promptify/models/nlp/openai_model.py
@@ -10,7 +10,7 @@ class OpenAI(Model):
     name = "OpenAI"
     description = "OpenAI API for text completion using various models"
 
-    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+    def __init__(self, api_key: str, model: str = "text-davinci-003"):
         self._api_key = api_key
         self.model = model
         self._openai = openai
@@ -39,6 +39,7 @@ class OpenAI(Model):
         self,
         # prompts: List[str],
         prompts,
+        model,
         temperature: float = 0.7,
         max_tokens: int = 4000,
         top_p: float = 0.1,
@@ -60,6 +61,8 @@ class OpenAI(Model):
         """
 
         result = []
+        if model:
+            self.model = model
 
         for prompt in prompts:
 
@@ -74,7 +77,6 @@ class OpenAI(Model):
                     model="gpt-3.5-turbo",
                     temperature=temperature,
                     max_tokens=max_tokens_prompt,
-                    # messages=[{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": prompt}],
                     messages=prompt,
                 )
 

--- a/promptify/prompts/nlp/prompter.py
+++ b/promptify/prompts/nlp/prompter.py
@@ -40,7 +40,7 @@ class Prompter:
         prompt = template.render(**kwargs).strip()
         return prompt
 
-    def fit(self, template_name, **kwargs):
+    def fit(self, template_name, model_name, **kwargs):
         prompt_variables = []
         if template_name == "bypass":
             pass
@@ -54,13 +54,11 @@ class Prompter:
             elif variable in self.model_variables:
                 model_kwargs[variable] = kwargs[variable]
         prompt= ""
-        # for variable in kwargs:
-        #     print(variable)
+
         if "prompt" in kwargs:
-            # if variable == "prompt":
             prompt =  kwargs['prompt']
         else:
             prompt = self.generate_prompt(template_name, **prompt_kwargs)
             
-        output = self.model.run(prompts=[prompt], **model_kwargs)
+        output = self.model.run(prompts=[prompt], model=model_name, **model_kwargs)
         return output[0]

--- a/promptify/prompts/nlp/prompter.py
+++ b/promptify/prompts/nlp/prompter.py
@@ -41,7 +41,11 @@ class Prompter:
         return prompt
 
     def fit(self, template_name, **kwargs):
-        prompt_variables = self.get_template_variables(template_name)
+        prompt_variables = []
+        if template_name == "bypass":
+            pass
+        else:
+            prompt_variables = self.get_template_variables(template_name)
         prompt_kwargs = {}
         model_kwargs = {}
         for variable in kwargs:
@@ -49,6 +53,14 @@ class Prompter:
                 prompt_kwargs[variable] = kwargs[variable]
             elif variable in self.model_variables:
                 model_kwargs[variable] = kwargs[variable]
-        prompt = self.generate_prompt(template_name, **prompt_kwargs)
+        prompt= ""
+        # for variable in kwargs:
+        #     print(variable)
+        if "prompt" in kwargs:
+            # if variable == "prompt":
+            prompt =  kwargs['prompt']
+        else:
+            prompt = self.generate_prompt(template_name, **prompt_kwargs)
+            
         output = self.model.run(prompts=[prompt], **model_kwargs)
         return output[0]


### PR DESCRIPTION
Only a draft PR so maintainers can try locally

A small change is required when the fit function of the prompter is called, model_name needs to be passed as a positional argument now for each use case to distinguish ( the logic there can be changed ) between davinci and chatgpt prompts.

Example is going to be converted to a real use case, anything would work actually.

After testing chatgpt example, classification notebook is also tested, when all prompter fit functions have model_name argument works just fine.