### PR TITLE
Remove unwanted paranthesis to avoid syntax error

### DIFF
--- a/promptify/prompts/text2text/ner/ner_openai.jinja
+++ b/promptify/prompts/text2text/ner/ner_openai.jinja
@@ -17,7 +17,7 @@ You are a highly intelligent and accurate Named-entity recognition(NER) system. 
 You are a highly intelligent and accurate Named-entity recognition(NER) system. You take Passage as input and your task is to recognize and extract specific types of named entities in that given passage and classify into a set of entity types.
 {%- endif -%}
 {% endif -%}
-Your output format is only {{ output_format|default("[{'T': type of entity from predefined entity types, 'E': entity in the input text}},...,{{'branch' : Appropriate branch of the passage ,'group': Appropriate Group of the passage}]") }} form, no other form. Don't include any text in response such as 'here are named entities..' etc, return only valid json
+Your output format is only {{ output_format|default("[{'T': type of entity from predefined entity types, 'E': entity in the input text},...,{'branch' : Appropriate branch of the passage ,'group': Appropriate Group of the passage}]") }} form, no other form. Don't include any text in response such as 'here are named entities..' etc, return only valid json
 
 {% if examples is defined and examples|length > 0 -%}
 Examples:


### PR DESCRIPTION
To Avoid Error:

`*** SyntaxError: closing parenthesis '}' does not match opening parenthesis '['`

For Output:

```
"[{'T': 'Age', 'E': '93-year-old'}, {'T': 'Gender', 'E': 'female'}, {'T': 'Medical Condition', 'E': 'chronic right hip pain'}, {'T': 'Medical Condition', 'E': 'osteoporosis'}, {'T': 'Medical Condition', 'E': 'hypertension'}, {'T': 'Medical Condition', 'E': 'depression'}, {'T': 'Medical Condition', 'E': 'chronic atrial fibrillation'}, {'T': 'Reason for Admission', 'E': 'evaluation and management of severe nausea and vomiting and urinary tract infection'}},{'branch': 'Appropriate branch of the passage', 'group': 'Appropriate Group of the passage'}]"
```
